### PR TITLE
:wrench: apply exact to react-route #3

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,8 +6,8 @@ import NotFound from './components/NotFound';
 const App: React.FC<{}> = () => (
     <div className='Container'>
       <Switch>
-        <Route path='/404' component={NotFound} />
-        <Route path='/' component={Home} />
+        <Route exact path='/404' component={NotFound} />
+        <Route exact path='/' component={Home} />
         <Redirect to='/' />
       </Switch>
     </div>


### PR DESCRIPTION
## PR内容
存在しないpathを指定した場合rootへリダイレクトするようにしました

## 変更点
- Routeにexactを指定（https://reacttraining.com/react-router/web/api/Route/exact-bool）